### PR TITLE
remove "throwas" from java.json keyword file

### DIFF
--- a/public/json/java.json
+++ b/public/json/java.json
@@ -57,7 +57,6 @@
   "put",
   "set",
   "with",
-  "throwas",
   "build",
   "add",
   "subtract",


### PR DESCRIPTION
Removes a typo from an existing keyword for Java language feed