### PR TITLE
Added functionality for Docker images to be run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Use Node.js base image
+FROM node:14-alpine
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+RUN npm run build
+
+# Port 3000
+EXPOSE 3000
+
+CMD ["npm", "start"]


### PR DESCRIPTION
Description: 
I have added a Dockerfile that can now build Docker images for this repository. I added these changes to make this application more portable and to simplify the collaboration of this project moving forward in the future.

Link to the Issue:
Fixes [Issue #10](https://github.com/MananTank/cybertype/issues/10)

Testing Steps:
You can test this Dockerized solution by building the Docker image with the command:
`docker build -t cyber-typer-app .`

Run the Docker image with the command (on Port 3000):
docker run -p 3000:3000 cyber-typer-app

Happy Testing and Good Luck in the Future!