### PR TITLE
Added case to go next word when pressing in the middle of a word

### DIFF
--- a/lib/state.ts
+++ b/lib/state.ts
@@ -98,6 +98,16 @@ export function stateReducer(state: State, action: Action): void {
       if (!state.typingStarted) {
         handleFirstKeyDown(state, now)
       }
+      if (
+        action.key === ' ' &&
+        state.progress.charIndex !== 0 &&
+        state.words[state.progress.wordIndex].length - 1 !== state.progress.charIndex
+      ) {
+        handleIncorrectKeyDown(state)
+        state.progress.wordIndex++
+        state.progress.charIndex = 0
+        return
+      }
 
       const isCorrect = action.key === targetKey
 


### PR DESCRIPTION
Hey,
This is very useful when typing. Basically if you're in the middle of a word and you want to go to the next word, you can just press space. Would be happy to have this on the app.